### PR TITLE
fix: continue processing with warnings when HCL parsing fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 third_party_licenses
+.serena

--- a/pkg/controller/find/backend.go
+++ b/pkg/controller/find/backend.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-func findBackendConfig(afs afero.Fs, dir string, bucket *Bucket) error {
+func findBackendConfig(logE *logrus.Entry, afs afero.Fs, dir string, bucket *Bucket) error {
 	// parse HCLs in dir and extract backend configurations
 	matchFiles, err := afero.Glob(afs, filepath.Join(dir, "*.tf"))
 	if err != nil {
@@ -27,7 +29,8 @@ func findBackendConfig(afs afero.Fs, dir string, bucket *Bucket) error {
 			continue
 		}
 		if f, err := extractBackend(b, matchFile, bucket); err != nil {
-			return fmt.Errorf("get backend configuration: %w", err)
+			logerr.WithError(logE, err).Warn("extract backend configuration")
+			continue
 		} else if f {
 			break
 		}

--- a/pkg/controller/find/find.go
+++ b/pkg/controller/find/find.go
@@ -75,7 +75,7 @@ func Find(_ context.Context, logE *logrus.Entry, afs afero.Fs, param *Param) err
 
 	if bucket.Bucket == "" {
 		// parse HCLs in dir and extract backend configurations
-		if err := findBackendConfig(afs, param.Dir, bucket); err != nil {
+		if err := findBackendConfig(logE, afs, param.Dir, bucket); err != nil {
 			return err
 		}
 	}
@@ -107,9 +107,8 @@ func Find(_ context.Context, logE *logrus.Entry, afs afero.Fs, param *Param) err
 			logE.Debug("terraform_remote_state is found")
 			remoteStates, err := extractRemoteStates(logE, file.Byte, file.Path, bucket)
 			if err != nil {
-				return fmt.Errorf("get terraform_remote_state: %w", logerr.WithFields(err, logrus.Fields{
-					"file": file.Path,
-				}))
+				logerr.WithError(logE, err).Warn("extract terraform_remote_state")
+				continue
 			}
 			dir.States = append(dir.States, remoteStates...)
 		}


### PR DESCRIPTION
## Summary
- Modified error handling to continue processing when HCL parsing fails
- Changed from failing immediately to logging warnings and continuing with other files

## Motivation
Previously, when tfrstate encountered an HCL file that couldn't be parsed (due to syntax errors or incompatible HCL features), the entire command would fail and stop processing. This was problematic when scanning large codebases that might contain malformed or work-in-progress Terraform files.

## Changes
- Added warning logs instead of returning errors when:
  - Backend configuration extraction fails
  - terraform_remote_state extraction fails
- The tool now continues processing other files even when individual files fail to parse
- Added proper error logging with context using `logerr.WithError()`

## Impact
This change makes tfrstate more resilient and practical for real-world usage, especially in CI/CD pipelines where a single malformed file shouldn't block the entire analysis.

## Test plan
- [x] Existing tests pass
- [ ] Manual testing with malformed HCL files confirms warnings are logged and processing continues